### PR TITLE
Fixed the issue with leaked instance at exit

### DIFF
--- a/addons/SimpleTODO/SimpleTODO.gd
+++ b/addons/SimpleTODO/SimpleTODO.gd
@@ -90,7 +90,10 @@ func _get_window_layout(configuration: ConfigFile):
 	configuration.set_value("SimpleTODO", "minimized_tabs", new_minimized_tabs)
 
 func _exit_tree():
-	todo_screen.queue_free()
+	if todo_screen:
+		if todo_screen.undo_redo:
+			todo_screen.undo_redo.free()
+		todo_screen.queue_free()
 
 func _make_visible(visible: bool) -> void:
 	todo_screen.visible = visible

--- a/addons/SimpleTODO/SimpleTODO.gd
+++ b/addons/SimpleTODO/SimpleTODO.gd
@@ -90,10 +90,8 @@ func _get_window_layout(configuration: ConfigFile):
 	configuration.set_value("SimpleTODO", "minimized_tabs", new_minimized_tabs)
 
 func _exit_tree():
-	if todo_screen:
-		if todo_screen.undo_redo:
-			todo_screen.undo_redo.free()
-		todo_screen.queue_free()
+	todo_screen.undo_redo.free()
+	todo_screen.queue_free()
 
 func _make_visible(visible: bool) -> void:
 	todo_screen.visible = visible


### PR DESCRIPTION
Thanks for a useful tool. I enjoy it very much. 
I found one minor bug. With your plugin enabled, I get this warning while closing Godot:
```
WARNING: ObjectDB instances leaked at exit (run with --verbose for details).
     at: cleanup (core/object/object.cpp:2378)
Leaked instance: UndoRedo:2151292156993
Hint: Leaked instances typically happen when nodes are removed from the scene tree (with `remove_child()`) but not freed (with `free()` or `queue_free()`).
```
This is my fix for that issue